### PR TITLE
Throttle down socket polling

### DIFF
--- a/src/bbsocketclient.c
+++ b/src/bbsocketclient.c
@@ -59,6 +59,7 @@ int bbsocket_query(const char *key, char *target, size_t max_len) {
       }
       return 0;
     }
+    usleep(100000); // delay before polling the socket again
   }
   bb_log(LOG_DEBUG, "Read failed for query of %s\n", key);
   return 1;


### PR DESCRIPTION
This is a safe way to avoid triggering Nvidia driver bug with GPU falling off
the bus.  A better way is not to use a non-blocking socket in the first place.
