### PR TITLE
dual-nvidia

### DIFF
--- a/conf/xorg.conf.nvidia
+++ b/conf/xorg.conf.nvidia
@@ -7,6 +7,26 @@ Section "Device"
     Identifier "Device1"
     Driver "nvidia"
     VendorName "NVIDIA Corporation"
+
+#   If the X server does not automatically detect your VGA device,
+#   you can manually set it here.
+#   To get the BusID prop, run `lspci | grep VGA` and input the data
+#   as you see in the commented example.
+#   This Setting may be needed in some platforms with more than one
+#   nvidia card, which may confuse the proprietary driver (e.g.,
+#   trying to take ownership of the wrong device).
+#   BusID "PCI:02:00:0"
+
+#   Setting ProbeAllGpus to false prevents the new proprietary driver
+#   instance spawned to try to control the integrated graphics card,
+#   which is already being managed outside bumblebee.
+#   This option doesn't hurt and it is required on platforms running
+#   more than one nvidia graphics card with the proprietary driver.
+#   (E.g. Macbook Pro pre-2010 with nVidia 9400M + 9600M GT).
+#   If this option is not set, the new Xorg may blacken the screen and
+#   render it unusable (unless you have some way to run killall Xorg).
+    Option "ProbeAllGpus" "false"
+
     Option "NoLogo" "true"
     Option "UseEDID" "false"
     Option "UseDisplayDevice" "none"

--- a/src/bumblebeed.c
+++ b/src/bumblebeed.c
@@ -458,16 +458,31 @@ int main(int argc, char* argv[]) {
   init_config();
   bbconfig_parse_opts(argc, argv, PARSE_STAGE_PRECONF);
 
-  pci_bus_id_discrete = pci_find_gfx_by_vendor(PCI_VENDOR_ID_NVIDIA);
-  if (!pci_bus_id_discrete) {
-    bb_log(LOG_ERR, "No nVidia graphics card found, quitting.\n");
-    return (EXIT_FAILURE);
-  }
-  struct pci_bus_id *pci_id_igd = pci_find_gfx_by_vendor(PCI_VENDOR_ID_INTEL);
+  /* First look for an intel card */
+  struct pci_bus_id *pci_id_igd = pci_find_gfx_by_vendor(PCI_VENDOR_ID_INTEL, 0);
   if (!pci_id_igd) {
-    bb_log(LOG_ERR, "No Optimus system detected, quitting.\n");
+    /* This is no Optimus configuration. But maybe it's a
+       dual-nvidia configuration. Let us test that.
+    */
+    pci_id_igd = pci_find_gfx_by_vendor(PCI_VENDOR_ID_NVIDIA, 1);
+    bb_log(LOG_INFO, "No Intel video card found, testing for dual-nvidia system.\n");
+
+    if (!pci_id_igd) {
+      /* Ok, this is not a double gpu setup supported (there is at most
+         one nvidia and no intel cards */
+      bb_log(LOG_ERR, "No integrated video card found, quitting.\n");
+      return (EXIT_FAILURE);
+    }
+  }
+  pci_bus_id_discrete = pci_find_gfx_by_vendor(PCI_VENDOR_ID_NVIDIA, 0);
+  if (!pci_bus_id_discrete) {
+    bb_log(LOG_ERR, "No discrete video card found, quitting\n");
     return (EXIT_FAILURE);
   }
+
+  bb_log(LOG_DEBUG, "Found card: %02x:%02x.%x (discrete)\n", pci_bus_id_discrete->bus, pci_bus_id_discrete->slot, pci_bus_id_discrete->func);
+  bb_log(LOG_DEBUG, "Found card: %02x:%02x.%x (integrated)\n", pci_id_igd->bus, pci_id_igd->slot, pci_id_igd->func);
+
   free(pci_id_igd);
 
   GKeyFile *bbcfg = bbconfig_parse_conf();

--- a/src/pci.c
+++ b/src/pci.c
@@ -76,10 +76,11 @@ int pci_get_class(struct pci_bus_id *bus_id) {
 /**
  * Finds the Bus ID a graphics card by vendor ID
  * @param vendor_id A numeric vendor ID
+ * @param index A numeric index (the card we want when we have many of a vendor)
  * @return A bus ID struct if a device was found, NULL if no device is found or
  * no memory could be allocated
  */
-struct pci_bus_id *pci_find_gfx_by_vendor(unsigned int vendor_id) {
+struct pci_bus_id *pci_find_gfx_by_vendor(unsigned int vendor_id, unsigned int idx) {
   FILE *fp;
   char buf[512];
   unsigned int bus_id_numeric, vendor_device;
@@ -105,7 +106,11 @@ struct pci_bus_id *pci_find_gfx_by_vendor(unsigned int vendor_id) {
         int pci_class = pci_get_class(result);
         if (pci_class == PCI_CLASS_DISPLAY_VGA ||
                 pci_class == PCI_CLASS_DISPLAY_3D) {
-          /* yay, found device. Now clean up and return */
+          /* yay, found device. Now get next, or clean up and return */
+          if (idx--) {
+            /* It's not yet our device */
+            continue;
+          }
           fclose(fp);
           return result;
         }

--- a/src/pci.h
+++ b/src/pci.h
@@ -34,7 +34,7 @@ struct pci_bus_id {
 
 int pci_parse_bus_id(struct pci_bus_id *dest, int bus_id_numeric);
 int pci_get_class(struct pci_bus_id *bus_id);
-struct pci_bus_id *pci_find_gfx_by_vendor(unsigned int vendor_id);
+struct pci_bus_id *pci_find_gfx_by_vendor(unsigned int vendor_id, unsigned int idx);
 size_t pci_get_driver(char *dest, struct pci_bus_id *bus_id, size_t len);
 
 struct pci_config_state {


### PR DESCRIPTION
This patch would make dual-nvidia cards work with Bumblebee (when no udev rule is installed, and there's no work on bbswitch about that yet).

It is not an NVidia Optimus configuration, but it is anyway supported by the code with this tiny fix.
I couldn't figure out how to know, when there's two nvidia cards, which one should be the discrete one, so the current setting is hardcoded so it matches my Laptop settings.

I can test this works on an Early 2009 Macbook Pro 17" (MacbookPro 5,1) with the proprietary nvidia drivers.

I could not test the project with nouveau, because nouveau does not work with my two nvidia cards' configuration at its current version.

For simplicity's sake, the get_by_vendor function has been replaced by get_by_kind(discrete|integrated), which actually makes sense if we don't restrict the project just to NVidia Optimus.
