### PR TITLE
Fix for Issue 401

### DIFF
--- a/conf/xorg.conf.d/10-dummy.conf
+++ b/conf/xorg.conf.d/10-dummy.conf
@@ -1,0 +1,3 @@
+Section "Device"
+    Identifier  "DiscreteNvidia"
+EndSection


### PR DESCRIPTION
This just adds an empty Device Section to the dummy xorg config file for the bumblebee xorg server. Not having this Device listed will disable the VGA output of (some?) NVIDIA cards. Having the VGA output work enables hot-plugging external Monitors via screenclone (see [Optimus Archlinux Graphics Setup for Thinkpads](http://blog.gordin.de/post/optimus-guide) or [Optimal Ubuntu Graphics Setup for Thinkpads](http://sagark.org/optimal-ubuntu-graphics-setup-for-thinkpads/)
Issue 401: https://github.com/Bumblebee-Project/Bumblebee/issues/401

Having this as a Hotfix would be nice as the 3.2 update effectively broke the use of multiple monitors for the people using screenclone.
