### PR TITLE
Error on X shutdown

### DIFF
--- a/src/bblogger.c
+++ b/src/bblogger.c
@@ -144,7 +144,8 @@ static void parse_xorg_output(char * string){
   /* Error lines are errors. */
   if (strncmp(string, "(EE)", 4) == 0){
     if (strstr(string, "Failed to load module \"kbd\"") ||
-            strstr(string, "No input driver matching")) {
+            strstr(string, "No input driver matching") ||
+            strstr(string, "Server terminated successfully")) {
       /* non-fatal errors */
       prio = LOG_DEBUG;
     } else {


### PR DESCRIPTION
When X exits, it emits an error stating that it is exiting:

> Aug 13 19:26:50 beta bumblebeed[5777]: [54001.328316] [ERROR][XORG] (EE) Server terminated successfully (0). Closing log file.

Bumblebee detects this as a real error and subsequently reports an error when querying server status (sending 'S' on bumblebee.socket) rather than stating that the server is not running: 

> Error (3.2.1): [XORG] (EE) Server terminated successfully (0). Closing log file.

Expected:

> Ready (3.2.1). X inactive. Discrete video card is off.

Bumblebee should discard this error, like it does with "Failed to load module kbd"
