### PR TITLE
Turn off screen saver in default configuration.

### DIFF
--- a/conf/xorg.conf.nvidia
+++ b/conf/xorg.conf.nvidia
@@ -2,6 +2,12 @@ Section "ServerLayout"
     Identifier  "Layout0"
     Option      "AutoAddDevices" "false"
     Option      "AutoAddGPU" "false"
+
+    # turn off integrated screen saver
+    Option          "BlankTime"     "0"
+    Option          "StandbyTime"   "0"
+    Option          "SuspendTime"   "0"
+    Option          "OffTime"       "0"
 EndSection
 
 Section "Device"


### PR DESCRIPTION
I noticed this issue while trying to calibrate a second screen connected using intel-virtual-output unattendedly. The screen kept going black after 10 minutes without any keyboard/mouse input, while ArgyllCMS/dispcalGUI was trying to measure colors. Disabling the screen saver on display :8 fixes this.

Probably, the same thing should be done for the nouveau, but I can't test this.