### PR TITLE
bumblebeed.service.in: fix logging

### DIFF
--- a/scripts/systemd/bumblebeed.service.in
+++ b/scripts/systemd/bumblebeed.service.in
@@ -3,10 +3,9 @@ Description=Bumblebee C Daemon
 
 [Service]
 Type=simple
-ExecStart=@SBINDIR@/bumblebeed
+ExecStart=@SBINDIR@/bumblebeed --use-syslog
 Restart=always
 RestartSec=60
-StandardOutput=kmsg
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
* `StandardOutput=kmsg` is not needed as everything on stdout and stderr is captured into the journal nowadays (ref.: [systemd-system.conf(5)](http://www.freedesktop.org/software/systemd/man/systemd-system.conf.html#LogLevel=));
* In stderr/stdout mode, bumblebeed uses custom priority prefixes (like `[INFO]`, `[ERROR]` etc.) which are not parsed by journald. Instead, when using syslog mode, message priorities are correctly passed to journald and saved in the journal.