### PR TITLE
Fix for nvidia_modeset

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -96,7 +96,9 @@ int module_unload(char *driver) {
     int retries = 30;
     bb_log(LOG_INFO, "Unloading %s driver\n", driver);
     char *mod_argv[] = {
-      "rmmod",
+      "modprobe",
+      "-r",
+      "nvidia_modeset",
       driver,
       NULL
     };

--- a/src/module.c
+++ b/src/module.c
@@ -93,19 +93,18 @@ int module_load(char *module_name, char *driver) {
  */
 int module_unload(char *driver) {
 
-  if (module_is_loaded(driver) == 1 &&
-            module_is_loaded("nvidia_modeset") == 1) {
+  if (module_is_loaded("nvidia_uvm") == 1) {
     int retries = 30;
-    bb_log(LOG_INFO, "Unloading %s driver\n", driver);
+    bb_log(LOG_INFO, "Unloading nvidia_uvm driver\n");
     char *mod_argv[] = {
       "modprobe",
       "-r",
-      "nvidia-modeset",
-      driver,
+      "nvidia_uvm",
+      "nvidia_modeset",
       NULL
     };
     bb_run_fork_wait(mod_argv, 10);
-    while (retries-- > 0 && module_is_loaded(driver) == 1) {
+    while (retries-- > 0 && module_is_loaded("nvidia_uvm") == 1) {
       usleep(100000);
     }
     if (module_is_loaded(driver) == 1) {
@@ -113,7 +112,27 @@ int module_unload(char *driver) {
       return 0;
     }
   }
-    else if (module_is_loaded(driver) == 1) {
+
+  else if (module_is_loaded("nvidia_modeset") == 1) {
+    int retries = 30;
+    bb_log(LOG_INFO, "Unloading nvidia_modeset driver\n");
+    char *mod_argv[] = {
+      "modprobe",
+      "-r",
+      "nvidia_modeset",
+      NULL
+    };
+    bb_run_fork_wait(mod_argv, 10);
+    while (retries-- > 0 && module_is_loaded("nvidia_modeset") == 1) {
+      usleep(100000);
+    }
+    if (module_is_loaded(driver) == 1) {
+      bb_log(LOG_ERR, "Unloading %s driver timed out.\n", driver);
+      return 0;
+    }
+  }
+
+  else if (module_is_loaded(driver) == 1) {
       int retries = 30;
       bb_log(LOG_INFO, "Unloading %s driver\n", driver);
       char *mod_argv[] = {
@@ -130,7 +149,7 @@ int module_unload(char *driver) {
         bb_log(LOG_ERR, "Unloading %s driver timed out.\n", driver);
         return 0;
       }
-    }
+  }
   return 1;
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -92,13 +92,15 @@ int module_load(char *module_name, char *driver) {
  * @return 1 if the driver is succesfully unloaded, 0 otherwise
  */
 int module_unload(char *driver) {
-  if (module_is_loaded(driver) == 1) {
+
+  if (module_is_loaded(driver) == 1 &&
+            module_is_loaded("nvidia_modeset") == 1) {
     int retries = 30;
     bb_log(LOG_INFO, "Unloading %s driver\n", driver);
     char *mod_argv[] = {
       "modprobe",
       "-r",
-      "nvidia_modeset",
+      "nvidia-modeset",
       driver,
       NULL
     };
@@ -111,6 +113,24 @@ int module_unload(char *driver) {
       return 0;
     }
   }
+    else if (module_is_loaded(driver) == 1) {
+      int retries = 30;
+      bb_log(LOG_INFO, "Unloading %s driver\n", driver);
+      char *mod_argv[] = {
+        "modprobe",
+        "-r",
+        driver,
+        NULL
+      };
+      bb_run_fork_wait(mod_argv, 10);
+      while (retries-- > 0 && module_is_loaded(driver) == 1) {
+        usleep(100000);
+      }
+      if (module_is_loaded(driver) == 1) {
+        bb_log(LOG_ERR, "Unloading %s driver timed out.\n", driver);
+        return 0;
+      }
+    }
   return 1;
 }
 


### PR DESCRIPTION
This should fix issue #699 without causing any problems for non-affected users. It should correctly detect if nvidia and nvidia_modeset are loaded, unload nvidia_modeset using `modprobe -r nvidia_modeset` (this also unloads nvidia), and log errors (as before). If it doesn't detect nvidia_modeset but detects "driver", then it will unload the detected driver just like before, except it does so using `modprobe -r "driver"` for consistency.