### PR TITLE
Possible fix for proper unloading modules (#699)

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -96,7 +96,8 @@ int module_unload(char *driver) {
     int retries = 30;
     bb_log(LOG_INFO, "Unloading %s driver\n", driver);
     char *mod_argv[] = {
-      "rmmod",
+      "modprobe",
+      "-r",
       driver,
       NULL
     };


### PR DESCRIPTION
Original `rmmod` doesn't resolve module dependencies. That's why we can't unload `nvidia` module, because of `nvidia_modeset` or `nvidia_uvm`. I think, that `modprobe -r` will resolve that problem, because it tries to unload all unnecesary, dependent modules.