### PR TITLE
Apply a modified version of the UVM patch found in issue #739

### DIFF
--- a/src/bbsecondary.c
+++ b/src/bbsecondary.c
@@ -230,8 +230,12 @@ static void switch_and_unload(void)
       if (switcher->status() != SWITCH_ON) {
         return;
       }
-      /* unload the driver loaded by the graphica card */
+      /* unload the driver loaded by the graphics card */
       if (pci_get_driver(driver, pci_bus_id_discrete, sizeof driver)) {
+        /* nvidia_modeset needs to be unloaded along with the nvidia module */
+        if (strstr(driver, "nvidia")) {
+          module_unload("nvidia_modeset");
+        }
         module_unload(driver);
       }
 


### PR DESCRIPTION
I've modified the patch in https://github.com/Bumblebee-Project/Bumblebee/issues/739 to remove nvidia_modeset before the nvidia module. Otherwise, module dependencies prevent nvidia from being unloaded.

Note that I do not check for the presence of nvidia_modeset... if someone has a suggestion your welcome to comment on the PR.