### PR TITLE
Bugfix to nvidia module unload.

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -96,7 +96,8 @@ int module_unload(char *driver) {
     int retries = 30;
     bb_log(LOG_INFO, "Unloading %s driver\n", driver);
     char *mod_argv[] = {
-      "rmmod",
+      "modprobe",
+      "-r",
       driver,
       NULL
     };


### PR DESCRIPTION
This replaces the broken _rmmod_ for _modprobe -r_ because modprobe follows modprobe.d rules.

To make nvidia be unloaded correctly, you need to add a /etc/modprobe.d rule containing the following:

remove nvidia modprobe -r --ignore-remove nvidia_drm nvidia-modeset nvidia-uvm nvidia

Works like a charm.