### PR TITLE
Better module loading/unloading

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ AM_CPPFLAGS = ${regular_CPPFLAGS} \
 		-DCONF_XORG='"$(bumblebeedconfdir)/xorg.conf.DRIVER"' \
 		-DCONF_XORG_DIR='"$(bumblebeedconfdir)/xorg.conf.d"'
 AM_CFLAGS = ${regular_CFLAGS} \
-		${x11_CFLAGS} ${libbsd_CFLAGS} ${glib_CFLAGS} \
+		${x11_CFLAGS} ${libbsd_CFLAGS} ${glib_CFLAGS} ${kmod_CFLAGS} \
 		-Wextra -funsigned-char -DGITVERSION='"${GITVERSION}"'
 
 noinst_SCRIPTS = scripts/systemd/bumblebeed.service \
@@ -50,12 +50,12 @@ bin_PROGRAMS = bin/optirun
 
 bin_optirun_SOURCES = src/module.c src/bbconfig.c src/bblogger.c src/bbrun.c \
 	src/bbsocket.c src/driver.c src/optirun.c src/bbsocketclient.c
-bin_optirun_LDADD = ${glib_LIBS} -lrt
+bin_optirun_LDADD = ${glib_LIBS} ${kmod_LIBS} -lrt
 bin_bumblebeed_SOURCES = src/pci.c src/bbconfig.c src/bblogger.c src/bbrun.c \
 	src/bbsocket.c src/module.c src/bbsecondary.c src/switch/switching.c \
 	src/switch/sw_bbswitch.c src/switch/sw_switcheroo.c \
 	src/driver.c src/bumblebeed.c
-bin_bumblebeed_LDADD = ${x11_LIBS} ${libbsd_LIBS} ${glib_LIBS} -lrt
+bin_bumblebeed_LDADD = ${x11_LIBS} ${libbsd_LIBS} ${glib_LIBS} ${kmod_LIBS} -lrt
 
 dist_doc_DATA = $(relnotes) README.markdown
 bumblebeedconf_DATA = conf/bumblebee.conf conf/xorg.conf.nouveau conf/xorg.conf.nvidia

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,7 +49,7 @@ sbin_PROGRAMS = bin/bumblebeed
 bin_PROGRAMS = bin/optirun
 
 bin_optirun_SOURCES = src/module.c src/bbconfig.c src/bblogger.c src/bbrun.c \
-	src/bbsocket.c src/driver.c src/optirun.c src/bbsocketclient.c
+	src/bbsocket.c src/optirun.c src/bbsocketclient.c
 bin_optirun_LDADD = ${glib_LIBS} ${kmod_LIBS} -lrt
 bin_bumblebeed_SOURCES = src/pci.c src/bbconfig.c src/bblogger.c src/bbrun.c \
 	src/bbsocket.c src/module.c src/bbsecondary.c src/switch/switching.c \

--- a/README.markdown
+++ b/README.markdown
@@ -19,6 +19,7 @@ The following packages are dependencies for the build process:
 - pkg-config
 - glib-2.0 and development headers
 - libx11 and development headers
+- libkmod2 and development headers
 - libbsd and development headers (if pidfile support is enabled, default yes)
 - help2man (optional, it is needed for building manual pages)
 

--- a/configure.ac
+++ b/configure.ac
@@ -122,6 +122,7 @@ AC_SUBST([regular_CFLAGS])
 # Checks for header files.
 PKG_CHECK_MODULES([x11], [x11])
 PKG_CHECK_MODULES([glib], [glib-2.0])
+PKG_CHECK_MODULES([kmod], [libkmod])
 AS_IF([test "x$with_pidfile" != xno], [
 		PKG_CHECK_MODULES([libbsd], [libbsd >= 0.2.0])
 		PKG_CHECK_EXISTS([libbsd = 0.2.0], [AC_DEFINE(HAVE_LIBBSD_020)])

--- a/src/bbconfig.c
+++ b/src/bbconfig.c
@@ -251,12 +251,6 @@ Bumblebee homepage: <http://Bumblebee-Project.org/>\n", out);
  */
 static int bbconfig_parse_common(int opt, char *value) {
   switch (opt) {
-    case 'q'://quiet mode
-      bb_status.verbosity = VERB_NONE;
-      break;
-    case OPT_DEBUG://debug mode
-      bb_status.verbosity = VERB_ALL;
-      break;
     case 'd'://X display number
       set_string_value(&bb_config.x_display, value);
       break;
@@ -306,6 +300,12 @@ void bbconfig_parse_opts(int argc, char *argv[], int conf_round) {
           if (bb_status.verbosity < VERB_ALL) {
             bb_status.verbosity++;
           }
+          break;
+        case 'q'://quiet mode
+          bb_status.verbosity = VERB_NONE;
+          break;
+        case OPT_DEBUG://debug mode
+          bb_status.verbosity = VERB_ALL;
           break;
         case 's': /* Unix socket to use for communication */
           set_string_value(&bb_config.socket_path, optarg);

--- a/src/bbconfig.h
+++ b/src/bbconfig.h
@@ -26,6 +26,7 @@
 #include <unistd.h> //for pid_t
 #include <limits.h> //for CHAR_MAX
 #include <glib.h>
+#include <libkmod.h>
 
 /* Daemon states */
 #define BB_DAEMON 1
@@ -118,6 +119,7 @@ struct bb_status_struct {
     int x_pipe[2];//pipes for reading/writing output from X's stdout/stderr
     gboolean use_syslog;
     char *program_name;
+    struct kmod_ctx *kmod_ctx;
 };
 
 /* Structure containing the configuration. */

--- a/src/bblogger.c
+++ b/src/bblogger.c
@@ -228,7 +228,7 @@ void check_xorg_pipe(void){
         /* line / buffer is full, process the remaining buffer the next round */
         repeat = 1;
       }
-    }else{
+    } else {
       if (r == 0 || (errno != EAGAIN && r == -1)){
         /* the pipe is closed/invalid. Clean up. */
         if (bb_status.x_pipe[0] != -1){close(bb_status.x_pipe[0]); bb_status.x_pipe[0] = -1;}
@@ -257,5 +257,5 @@ void check_xorg_pipe(void){
         memmove(x_output_buffer, next_part, x_buffer_pos);
       }
     }
-  }while(repeat);
+  }while (repeat);
 }/* check_xorg_pipe */

--- a/src/bumblebeed.c
+++ b/src/bumblebeed.c
@@ -461,6 +461,7 @@ int main(int argc, char* argv[]) {
   /* first load the config to make the logging verbosity level available */
   init_config();
   bbconfig_parse_opts(argc, argv, PARSE_STAGE_PRECONF);
+  bbconfig_parse_opts(argc, argv, PARSE_STAGE_OTHER);
 
   /* First look for an intel card */
   struct pci_bus_id *pci_id_igd = pci_find_gfx_by_vendor(PCI_VENDOR_ID_INTEL, 0);
@@ -496,7 +497,6 @@ int main(int argc, char* argv[]) {
     bbconfig_parse_conf_driver(bbcfg, bb_config.driver);
     g_key_file_free(bbcfg);
   }
-  bbconfig_parse_opts(argc, argv, PARSE_STAGE_OTHER);
   check_pm_method();
 
   /* dump the config after detecting the driver */

--- a/src/bumblebeed.c
+++ b/src/bumblebeed.c
@@ -503,8 +503,7 @@ int main(int argc, char* argv[]) {
   config_dump();
 
   // kmod context have to be available for config validation
-  const char *null_cfg = NULL;
-  bb_status.kmod_ctx = kmod_new(NULL, &null_cfg);
+  bb_status.kmod_ctx = kmod_new(NULL, NULL);
   if (bb_status.kmod_ctx == NULL) {
     bb_log(LOG_ERR, "kmod_new() failed!\n");
     bb_closelog();

--- a/src/bumblebeed.c
+++ b/src/bumblebeed.c
@@ -490,6 +490,14 @@ int main(int argc, char* argv[]) {
 
   free(pci_id_igd);
 
+  // kmod context have to be available for driver detection
+  bb_status.kmod_ctx = kmod_new(NULL, NULL);
+  if (bb_status.kmod_ctx == NULL) {
+    bb_log(LOG_ERR, "kmod_new() failed!\n");
+    bb_closelog();
+    exit(EXIT_FAILURE);
+  }
+
   GKeyFile *bbcfg = bbconfig_parse_conf();
   bbconfig_parse_opts(argc, argv, PARSE_STAGE_DRIVER);
   driver_detect();
@@ -501,14 +509,6 @@ int main(int argc, char* argv[]) {
 
   /* dump the config after detecting the driver */
   config_dump();
-
-  // kmod context have to be available for config validation
-  bb_status.kmod_ctx = kmod_new(NULL, NULL);
-  if (bb_status.kmod_ctx == NULL) {
-    bb_log(LOG_ERR, "kmod_new() failed!\n");
-    bb_closelog();
-    exit(EXIT_FAILURE);
-  }
 
   if (config_validate() != 0) {
     return (EXIT_FAILURE);

--- a/src/bumblebeed.c
+++ b/src/bumblebeed.c
@@ -461,7 +461,6 @@ int main(int argc, char* argv[]) {
   /* first load the config to make the logging verbosity level available */
   init_config();
   bbconfig_parse_opts(argc, argv, PARSE_STAGE_PRECONF);
-  bbconfig_parse_opts(argc, argv, PARSE_STAGE_OTHER);
 
   /* First look for an intel card */
   struct pci_bus_id *pci_id_igd = pci_find_gfx_by_vendor(PCI_VENDOR_ID_INTEL, 0);
@@ -505,6 +504,7 @@ int main(int argc, char* argv[]) {
     bbconfig_parse_conf_driver(bbcfg, bb_config.driver);
     g_key_file_free(bbcfg);
   }
+  bbconfig_parse_opts(argc, argv, PARSE_STAGE_OTHER);
   check_pm_method();
 
   /* dump the config after detecting the driver */

--- a/src/module.c
+++ b/src/module.c
@@ -44,7 +44,7 @@ int module_is_loaded(char *driver) {
   struct kmod_module *mod;
 
   err = kmod_module_new_from_name(bb_status.kmod_ctx, driver, &mod);
-  if(err < 0) {
+  if (err < 0) {
     bb_log(LOG_DEBUG, "kmod_module_new_from_name(%s) failed (err: %d).\n",
       driver, err);
     return 0;
@@ -74,13 +74,13 @@ int module_load(char *module_name, char *driver) {
     bb_log(LOG_INFO, "Loading driver '%s' (module '%s')\n", driver, module_name);
     err = kmod_module_new_from_lookup(bb_status.kmod_ctx, module_name, &list);
 
-    if(err < 0) {
+    if (err < 0) {
       bb_log(LOG_DEBUG, "kmod_module_new_from_lookup(%s) failed (err: %d).\n",
         module_name, err);
       return 0;
     }
 
-    if(list == NULL) {
+    if (list == NULL) {
       bb_log(LOG_ERR, "Module '%s' not found.\n", module_name);
       return 0;
     }
@@ -98,7 +98,7 @@ int module_load(char *module_name, char *driver) {
 
       kmod_module_unref(mod);
 
-      if(err < 0) {
+      if (err < 0) {
         break;
       }
     }
@@ -128,7 +128,7 @@ int module_unload_recursive(struct kmod_module *mod) {
       err = module_unload_recursive(hm);
       kmod_module_unref(hm);
 
-      if(err < 0) {
+      if (err < 0) {
         break;
       }
     }
@@ -136,7 +136,7 @@ int module_unload_recursive(struct kmod_module *mod) {
   }
 
   refcnt = kmod_module_get_refcnt(mod);
-  if(refcnt == 0) {
+  if (refcnt == 0) {
     bb_log(LOG_INFO, "Unloading module %s\n", kmod_module_get_name(mod));
     err = kmod_module_remove_module(mod, flags);
   } else {
@@ -160,7 +160,7 @@ int module_unload(char *driver) {
   if (module_is_loaded(driver) == 1) {
     err = kmod_module_new_from_name(bb_status.kmod_ctx, driver, &mod);
 
-    if(err < 0) {
+    if (err < 0) {
       bb_log(LOG_DEBUG, "kmod_module_new_from_name(%s) failed (err: %d).\n",
         driver, err);
       return 0;
@@ -186,7 +186,7 @@ int module_is_available(char *module_name) {
 
   err = kmod_module_new_from_lookup(bb_status.kmod_ctx, module_name, &list);
 
-  if(err < 0) {
+  if (err < 0) {
     bb_log(LOG_DEBUG, "kmod_module_new_from_lookup(%s) failed (err: %d).\n",
       module_name, err);
     return 0;

--- a/src/module.c
+++ b/src/module.c
@@ -189,9 +189,10 @@ int module_is_available(char *module_name) {
   if(err < 0) {
     bb_log(LOG_DEBUG, "kmod_module_new_from_lookup(%s) failed (err: %d).\n",
       module_name, err);
+    return 0;
   }
 
-  available = (err == 0) && list != NULL;
+  available = list != NULL;
 
   kmod_module_unref_list(list);
 

--- a/src/module.c
+++ b/src/module.c
@@ -81,7 +81,7 @@ int module_load(char *module_name, char *driver) {
     }
 
     if(list == NULL) {
-      bb_log(LOG_ERR, "Module '%s' not found.\n");
+      bb_log(LOG_ERR, "Module '%s' not found.\n", module_name);
       return 0;
     }
 

--- a/src/module.c
+++ b/src/module.c
@@ -45,8 +45,9 @@ int module_is_loaded(char *driver) {
 
   err = kmod_module_new_from_name(bb_status.kmod_ctx, driver, &mod);
   if(err < 0) {
-    bb_log(LOG_DEBUG, "kmod_module_new_from_name(%s) failed.\n", driver);
-    return -1;
+    bb_log(LOG_DEBUG, "kmod_module_new_from_name(%s) failed (err: %d).\n",
+      driver, err);
+    return 0;
   }
 
   state = kmod_module_get_initstate(mod);

--- a/src/optirun.c
+++ b/src/optirun.c
@@ -37,7 +37,6 @@
 #include "bbsocketclient.h"
 #include "bblogger.h"
 #include "bbrun.h"
-#include "driver.h"
 
 
 /**


### PR DESCRIPTION
This replaces `modprobe` execution with `libkmod2` library calls.

This change also fixes problems with nvidia modules unloading (alternative to #751) as it unloads all depending modules automatically. Plus module handling is more flexible.

Please give it a try.