### PR TITLE
Add config option to set Xorg binary to run

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -70,6 +70,7 @@ endif
 
 do_subst = sed -e 's|[@]GITVERSION[@]|$(GITVERSION)|g' \
 	-e 's|[@]CONF_XDISP[@]|$(CONF_XDISP)|g' \
+	-e 's|[@]CONF_XORG_BINARY[@]|$(CONF_XORG_BINARY)|g' \
 	-e 's|[@]CONF_SOCKPATH[@]|$(CONF_SOCKPATH)|g' \
 	-e 's|[@]CONF_GID[@]|$(CONF_GID)|g' \
 	-e 's|[@]CONF_PM_METHOD[@]|$(CONF_PM_METHOD)|g' \

--- a/conf/bumblebee.conf.in
+++ b/conf/bumblebee.conf.in
@@ -22,6 +22,8 @@ NoEcoModeOverride=false
 Driver=@CONF_DRIVER@
 # Directory with a dummy config file to pass as a -configdir to secondary X
 XorgConfDir=@XCONFDDIR@
+# Xorg binary to run
+XorgBinary=@CONF_XORG_BINARY@
 
 ## Client options. Will take effect on the next optirun executed.
 [optirun]

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,21 @@ AC_DEFINE_SUBST(CONF_FALLBACKSTART, "false", [make optirun start applications no
 AC_DEFINE_SUBST(CONF_VGLCOMPRESS, "proxy", [vglclient transport method])
 AC_DEFINE_SUBST(CONF_TURNOFFATEXIT, "false", [state of card when shutting off daemon])
 
+# OpenSUSE: /usr/bin/X -> /var/lib/X11/X -> /usr/bin/Xorg
+# Fedora, Arch Linux: /usr/bin/X -> /usr/bin/Xorg
+# Ubuntu: /usr/bin/X is a custom binary doing authorization and then executes
+#         /etc/X11/X -> /usr/bin/Xorg
+# Debian/Ubuntu and Xorg >= 1.18: /usr/bin/Xorg is a script that will run either the normal
+#                                 Xorg binary from /usr/lib/xorg/Xorg, or a SETUID
+#                                 wrapper at /usr/lib/xorg/Xorg.wrap
+#                                 Use this setting to run /usr/lib/xorg/Xorg specifically
+#                                 in that case.
+AC_DEFINE_CONF(CONF_XORG_BINARY, [Xorg binary to run], [
+if test "x" = "x$CONF_XORG_BINARY"; then
+	CONF_XORG_BINARY=Xorg
+fi
+])
+
 AC_DEFINE_CONF(CONF_BRIDGE, [optirun display/render bridge, valid values are auto (default), primus and virtualgl], [
 case $CONF_BRIDGE in
 auto|primus|virtualgl) ;;

--- a/src/bbconfig.c
+++ b/src/bbconfig.c
@@ -425,6 +425,10 @@ GKeyFile *bbconfig_parse_conf(void) {
   if (g_key_file_has_key(bbcfg, section, key, NULL)) {
     free_and_set_value(&bb_config.x_conf_dir, g_key_file_get_string(bbcfg, section, key, NULL));
   }
+  key = "XorgBinary";
+  if (g_key_file_has_key(bbcfg, section, key, NULL)) {
+    free_and_set_value(&bb_config.xorg_binary, g_key_file_get_string(bbcfg, section, key, NULL));
+  }
   return bbcfg;
 }
 
@@ -517,6 +521,7 @@ void init_config(void) {
   set_string_value(&bb_config.gid_name, CONF_GID);
   set_string_value(&bb_config.x_conf_file, CONF_XORG);
   set_string_value(&bb_config.x_conf_dir, CONF_XORG_DIR);
+  set_string_value(&bb_config.xorg_binary, CONF_XORG_BINARY);
   set_string_value(&bb_config.optirun_bridge, CONF_BRIDGE);
   set_string_value(&bb_config.primus_ld_path, CONF_PRIMUS_LD_PATH);
   set_string_value(&bb_config.vgl_compress, CONF_VGLCOMPRESS);
@@ -550,6 +555,7 @@ void config_dump(void) {
 #endif
     bb_log(LOG_DEBUG, " xorg.conf file: %s\n", bb_config.x_conf_file);
     bb_log(LOG_DEBUG, " xorg.conf.d dir: %s\n", bb_config.x_conf_dir);
+    bb_log(LOG_DEBUG, " Xorg binary: %s\n", bb_config.xorg_binary);
     bb_log(LOG_DEBUG, " ModulePath: %s\n", bb_config.mod_path);
     bb_log(LOG_DEBUG, " GID name: %s\n", bb_config.gid_name);
     bb_log(LOG_DEBUG, " Power method: %s\n",

--- a/src/bbconfig.h
+++ b/src/bbconfig.h
@@ -122,6 +122,7 @@ struct bb_status_struct {
 
 /* Structure containing the configuration. */
 struct bb_config_struct {
+    char * xorg_binary; /// Xorg binary to run.
     char * x_display; /// X display number to use.
     char * x_conf_file; /// Path to the X configuration file.
     char * x_conf_dir; /// Path to the dummy X configuration directory.

--- a/src/bbsecondary.c
+++ b/src/bbsecondary.c
@@ -146,7 +146,7 @@ bool start_secondary(bool need_secondary) {
 
     bb_log(LOG_INFO, "Starting X server on display %s.\n", bb_config.x_display);
     char *x_argv[] = {
-      XORG_BINARY,
+      bb_config.xorg_binary,
       bb_config.x_display,
       "-config", x_conf_file,
       "-configdir", bb_config.x_conf_dir,
@@ -158,6 +158,12 @@ bool start_secondary(bool need_secondary) {
       "-modulepath", bb_config.mod_path, // keep last
       NULL
     };
+    char **argvp;
+    bb_log(LOG_DEBUG, "X server command line:");
+    for (argvp = x_argv; *argvp; argvp++) {
+	    bb_log(LOG_DEBUG, " %s", *argvp);
+    }
+    bb_log(LOG_DEBUG, "\n");
     enum {n_x_args = sizeof(x_argv) / sizeof(x_argv[0])};
     if (!*bb_config.mod_path) {
       x_argv[n_x_args - 3] = 0; //remove -modulepath if not set

--- a/src/bbsecondary.h
+++ b/src/bbsecondary.h
@@ -20,14 +20,6 @@
  */
 #pragma once
 
-/**
- * OpenSUSE: /usr/bin/X -> /var/lib/X11/X -> /usr/bin/Xorg
- * Fedora, Arch Linux: /usr/bin/X -> /usr/bin/Xorg
- * Ubuntu: /usr/bin/X is a custom binary doing authorization and then executes
- *         /etc/X11/X -> /usr/bin/Xorg
- */
-#define XORG_BINARY "Xorg"
-
 /* PCI Bus ID of the discrete video card */
 struct pci_bus_id *pci_bus_id_discrete;
 


### PR DESCRIPTION
Also add Xorg commandline to debug output. Config option can be tweaked
at compile time, for packaging convenience.