### PR TITLE
Fix switcheroo_status signature to match header

### DIFF
--- a/src/switch/sw_bbswitch.c
+++ b/src/switch/sw_bbswitch.c
@@ -38,7 +38,7 @@
  */
 enum switch_state bbswitch_status(void) {
   char buffer[BBS_BUFFER];
-  int ret = SWITCH_UNAVAIL;
+  enum switch_state ret = SWITCH_UNAVAIL;
   FILE * bbs = fopen(BBSWITCH_PATH, "r");
   if (bbs == 0) {
     return SWITCH_UNAVAIL;

--- a/src/switch/sw_switcheroo.c
+++ b/src/switch/sw_switcheroo.c
@@ -34,9 +34,9 @@
  * @return SWITCH_OFF if card is off, SWITCH_ON if card is on and SWITCH_UNAVAIL
  * if switcheroo not available
  */
-int switcheroo_status(void) {
+enum switch_state switcheroo_status(void) {
   char buffer[BBS_BUFFER];
-  int ret = SWITCH_UNAVAIL;
+  enum switch_state ret = SWITCH_UNAVAIL;
   FILE * bbs = fopen(SWITCHEROO_PATH, "r");
   if (bbs == 0) {
     return SWITCH_UNAVAIL;


### PR DESCRIPTION
switching.h declares switcheroo_status to return enum switch_state,
but the implementation in sw_switcheroo.c uses and returns an int.
Fix the the return type to match the header declaration, and fix
it (and bbswitch_status) to use a enum switch_state type variable.

Reported by Michael Tautschnig <mt@debian.org> on the Debian BTS: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=749615