### PR TITLE
[RFC] Ignore failure to set DRM interface

### DIFF
--- a/src/bblogger.c
+++ b/src/bblogger.c
@@ -147,6 +147,7 @@ static void parse_xorg_output(char * string){
             strstr(string, "Failed to load module \"mouse\"") ||
             strstr(string, "No input driver matching") ||
             strstr(string, "systemd-logind: failed to get session:") ||
+            strstr(string, "failed to set DRM interface version 1.4:") ||
             strstr(string, "Server terminated successfully")) {
       /* non-fatal errors */
       prio = LOG_DEBUG;


### PR DESCRIPTION
This always fail due to problems in libdrm, but does not affect
Bumblebee's functionality. See GH-652 for more details.

`XORG] (EE) /dev/dri/card0: failed to set DRM interface version 1.4: Permission denied`

This throws user off track often, since it's reported whether or not Bumblebee works, so IMHO we should ignore it. A user spent some time investigating, and apparently it's down to a problem in libdrm: #652 