### PR TITLE
Fix make distcheck and add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+# Travis CI script
+
+language: c
+
+os:
+- linux
+
+dist: trusty
+
+sudo: required
+
+addons:
+  apt:
+    packages:
+    - libbsd-dev
+    - libglib2.0-dev
+    - libx11-dev
+    - libkmod-dev
+
+script: autoreconf -fi && ./configure && make distcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,8 @@
 GITVERSION = $(shell "$(top_srcdir)/version.sh" "$(top_srcdir)")
 relnotes = doc/RELEASE_NOTES_3_2_1
 
+DISTCHECK_CONFIGURE_FLAGS = --with-udev-rules=$$dc_install_base/lib/udev/rules.d
+
 bumblebeedconfdir=$(sysconfdir)/bumblebee
 
 AM_CPPFLAGS = ${regular_CPPFLAGS} \

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,9 +39,17 @@ EXTRA_DIST = scripts/systemd/bumblebeed.service.in \
 	scripts/bash_completion/bumblebee \
 	scripts/bumblebee-bugreport.in \
 	$(relnotes) \
-	version.sh
-# for laziness include all headers found
-EXTRA_DIST += src/*.h src/*/switching.h
+	version.sh \
+	src/bbconfig.h \
+	src/bblogger.h \
+	src/bbrun.h \
+	src/bbsecondary.h \
+	src/bbsocketclient.h \
+	src/bbsocket.h \
+	src/driver.h \
+	src/module.h \
+	src/pci.h \
+	src/switch/switching.h
 
 if WITH_PIDFILE
 EXTRA_DIST += scripts/sysvinit/bumblebeed.in


### PR DESCRIPTION
@ArchangeGabriel @Lekensteyn - As discussed here: https://github.com/Bumblebee-Project/Bumblebee/issues/772#issuecomment-220603583 we could upload dist tarballs via Travis directly on Github. We also get a build CI for free :-)

Once it's setup, after pushing a tag on the designated branch you'll automatically get the release and the make dist deploy, and this is how it looks like: https://github.com/bluca/Bumblebee/releases/tag/3.2.1-test
This is the CI build: https://travis-ci.org/bluca/Bumblebee/builds/134895811

If you guys like it, I'll setup Travis for this repository, and create an OAUTH token that can be used. An additional commit will be needed to use those, it will look like this but with different data: https://github.com/bluca/Bumblebee/commit/9390eb0ea7c9eddee3cae58f0de9a581565c1d5e