### PR TITLE
Deploy make dist tarballs on Github via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,26 @@ addons:
     - libkmod-dev
 
 script: autoreconf -fi && ./configure && make distcheck
+
+before_deploy:
+- mkdir dist;
+- export FILES=dist/*
+- mv *.tar.gz dist
+- cd dist
+- sha512sum *.tar.gz > SHA512SUMS
+- sha256sum *.tar.gz > SHA256SUMS
+- sha1sum *.tar.gz > SHA1SUMS
+- md5sum *.tar.gz > MD5SUMS
+- cd -
+
+deploy:
+  provider: releases
+  api_key:
+    secure: T5lqhqfyuV+C+NMw8Tm5VY3HFuSTzuzTnurUoH7JN2HRfKKDFm9qgCj9rfrHnMBx448WmlwJnuVEalaZ9R4vtLseNapJvOI0yUhst+dnLz+MUyY7Mts3YiJT4AhPCuygaotu9NIENLuc4NS1K8nv3L1QDzSExeEesqOP2baTmoU=
+  file: "${FILES}"
+  skip_cleanup: true
+  file_glob: true
+  on:
+    repo: Bumblebee-Project/Bumblebee
+    branch: master
+    tags: true


### PR DESCRIPTION
@Lekensteyn @ArchangeGabriel - this will have Travis upload the result of make dist to Github when a tag is pushed to the master branch.

Note that getting the secure token right is a bit of a pain and it's per-repo, so if this PR is merged and after develop is merged into master I'll do a test run with a test tag, to be sure that I got it right.

The token comes from my profile, if you prefer to hold it in one of your profiles it can be generated like this:

Go to https://github.com/settings/tokens/new
As "Token description" use `<ORG>/<REPO>`, eg: `Bumblebee-Project/Bumblebee`, and tick the "public_repo" option, and then "Generate token"

```
sudo gem install travis
travis encrypt --org -r <ORG>/<REPO> <TOKEN>
```

Add the output encrypted token as the "secure" parameter in .travis.yml.
