### PR TITLE
No longer using deprecated function have in bash_completion

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,7 +36,7 @@ EXTRA_DIST = scripts/systemd/bumblebeed.service.in \
 	conf/xorg.conf.nouveau \
 	$(xconfd_DATA) \
 	README.markdown \
-	scripts/bash_completion/bumblebee \
+	scripts/bash_completion/optirun \
 	scripts/bumblebee-bugreport.in \
 	$(relnotes) \
 	version.sh \
@@ -71,7 +71,7 @@ dist_doc_DATA = $(relnotes) README.markdown
 bumblebeedconf_DATA = conf/bumblebee.conf conf/xorg.conf.nouveau conf/xorg.conf.nvidia
 
 completiondir = $(sysconfdir)/bash_completion.d
-completion_DATA = scripts/bash_completion/bumblebee
+completion_DATA = scripts/bash_completion/optirun
 
 if WITH_UDEV_RULES
 udevrulesdir = $(UDEV_RULES_DIR)

--- a/scripts/bash_completion/bumblebee
+++ b/scripts/bash_completion/bumblebee
@@ -63,5 +63,5 @@ _optirun() {
     # after the options, auto-complete command
     _command_offset $i
 }
-have optirun && complete -F _optirun optirun
+_have optirun && complete -F _optirun optirun
 

--- a/scripts/bash_completion/optirun
+++ b/scripts/bash_completion/optirun
@@ -1,4 +1,4 @@
-# bash completion for bumblebee
+# bash completion for optirun
 
 _optirun() {
     local i prev cur last_optirun_offset compress_types in_option
@@ -63,5 +63,5 @@ _optirun() {
     # after the options, auto-complete command
     _command_offset $i
 }
-_have optirun && complete -F _optirun optirun
+complete -F _optirun optirun
 


### PR DESCRIPTION
have function has been deprecated in favour of _have
https://github.com/scop/bash-completion/blob/master/bash_completion#L121-L128