### PR TITLE
switch: fix wrong use of fwrite

### DIFF
--- a/src/switch/sw_bbswitch.c
+++ b/src/switch/sw_bbswitch.c
@@ -70,7 +70,7 @@ static void bbswitch_write(char *msg) {
     bb_log(LOG_ERR, "Could not open %s: %s\n", BBSWITCH_PATH, strerror(errno));
     return;
   }
-  fwrite(msg, sizeof msg, strlen(msg) + 1, bbs);
+  fputs(msg, bbs);
   if (ferror(bbs)) {
     bb_log(LOG_WARNING, "Could not write to %s: %s\n", BBSWITCH_PATH,
             strerror(errno));

--- a/src/switch/sw_switcheroo.c
+++ b/src/switch/sw_switcheroo.c
@@ -66,7 +66,7 @@ static void switcheroo_write(char *msg) {
             strerror(errno));
     return;
   }
-  fwrite(msg, sizeof msg, strlen(msg) + 1, bbs);
+  fputs(msg, bbs);
   if (ferror(bbs)) {
     bb_log(LOG_WARNING, "Could not write to %s: %s\n", SWITCHEROO_PATH,
             strerror(errno));


### PR DESCRIPTION
The previously written call to fwrite would write more data than
available. This could pontentially lead to a segmentation fault.

Signed-off-by: Celelibi <celelibi@gmail.com>