### PR TITLE
Only look for socket connections to X server.

### DIFF
--- a/src/bbsecondary.c
+++ b/src/bbsecondary.c
@@ -184,8 +184,10 @@ bool start_secondary(bool need_secondary) {
   //check if X is available, for maximum 10 seconds.
   time_t xtimer = time(0);
   Display * xdisp = 0;
+  char unix_x_display[5 + sizeof(bb_config.x_display)] = "unix/";
+  strcat(unix_x_display, bb_config.x_display);
   while ((time(0) - xtimer <= 10) && bb_is_running(bb_status.x_pid)) {
-    xdisp = XOpenDisplay(bb_config.x_display);
+    xdisp = XOpenDisplay(unix_x_display);
     if (xdisp != 0) {
       break;
     }

--- a/src/bbsecondary.c
+++ b/src/bbsecondary.c
@@ -184,8 +184,8 @@ bool start_secondary(bool need_secondary) {
   //check if X is available, for maximum 10 seconds.
   time_t xtimer = time(0);
   Display * xdisp = 0;
-  char unix_x_display[5 + sizeof(bb_config.x_display)] = "unix/";
-  strcat(unix_x_display, bb_config.x_display);
+  char unix_x_display[16];
+  snprintf(unix_x_display, sizeof(unix_x_display), "unix/%s", bb_config.x_display);
   while ((time(0) - xtimer <= 10) && bb_is_running(bb_status.x_pid)) {
     xdisp = XOpenDisplay(unix_x_display);
     if (xdisp != 0) {


### PR DESCRIPTION
`XOpenDisplay` tries all protocolls in turn (socket, IPv4, IPv6) [1]. This can lead to delays and timeouts, especially on systems with incomplete `/etc/hosts` (eg. missing `localhost` → `127.0.0.1`), due to the fact that the hostname has to be resolved.

Since we start the X server not accepting TCP connections, we can pass the protocoll to `XOpenDisplay`.

Closes #782.

[1] http://xwindow.angelfire.com/page2.html