### PR TITLE
An option to unload the driver even without active PM method

### DIFF
--- a/src/bbconfig.c
+++ b/src/bbconfig.c
@@ -462,6 +462,10 @@ void bbconfig_parse_conf_driver(GKeyFile *bbcfg, char *driver) {
       g_free(module_name);
     }
   }
+  key = "AlwaysUnloadKernelDriver";
+  if (g_key_file_has_key(bbcfg, section, key, NULL)) {
+    bb_config.force_driver_unload = g_key_file_get_boolean(bbcfg, section, key, NULL);
+  }
   key = "LibraryPath";
   if (g_key_file_has_key(bbcfg, section, key, NULL)) {
     free_and_set_value(&bb_config.ld_path, g_key_file_get_string(bbcfg, section, key, NULL));

--- a/src/bbconfig.h
+++ b/src/bbconfig.h
@@ -145,6 +145,7 @@ struct bb_config_struct {
     char * module_name; /* Kernel module to be loaded for the driver.
                                     * If empty, driver will be used. This is
                                     * for Ubuntu which uses nvidia-current */
+    int force_driver_unload; /* Force driver unload, even without active PM method */
     int card_shutdown_state;
 #ifdef WITH_PIDFILE
     char *pid_file; /* pid file for storing the daemons PID */


### PR DESCRIPTION
On the ArchLinux forum there's a discussion regarding bumblebee/bbswitch support for Dell XPS 15 9570. Dell has changed something with this model which broke bbswitch.
On the other hand the standard Linux power management is able to properly turn off the card. If `/sys/bus/pci/devices/0000:01:00.0/power/control` (PCI bus for the dGPU in Dell) is set to `auto` and no driver for the card is loaded (or gets unloaded), Linux shuts down the power to the card (confirmed in powertop and with the extended work time on the battery) and turns it on when the module is loaded. This means that bbswitch is not needed in case of this model (shouldn't even be installed in the system), but we still need Bumblebee to unload the module.
This PR adds `AlwaysUnloadKernelDriver` boolean configuration option, which can be added to driver-* section. If it's not added or is set to false, then Bumblebee works as before. But when this option is set to true, then even with PM method disabled, Bumblebee unloads the driver.