### PR TITLE
Support for AMD APU+NVIDIA setup

### DIFF
--- a/src/bumblebeed.c
+++ b/src/bumblebeed.c
@@ -464,12 +464,19 @@ int main(int argc, char* argv[]) {
 
   /* First look for an intel card */
   struct pci_bus_id *pci_id_igd = pci_find_gfx_by_vendor(PCI_VENDOR_ID_INTEL, 0);
+
+  /* Then look for an amd card */
+  if (!pci_id_igd) {
+    bb_log(LOG_INFO, "No Intel video card found, testing for system with an AMD APU.\n");
+    pci_id_igd = pci_find_gfx_by_vendor(PCI_VENDOR_ID_AMD, 0);
+  }
+
   if (!pci_id_igd) {
     /* This is no Optimus configuration. But maybe it's a
        dual-nvidia configuration. Let us test that.
     */
     pci_id_igd = pci_find_gfx_by_vendor(PCI_VENDOR_ID_NVIDIA, 1);
-    bb_log(LOG_INFO, "No Intel video card found, testing for dual-nvidia system.\n");
+    bb_log(LOG_INFO, "No Intel/AMD video card found, testing for dual-nvidia system.\n");
 
     if (!pci_id_igd) {
       /* Ok, this is not a double gpu setup supported (there is at most

--- a/src/pci.h
+++ b/src/pci.h
@@ -21,6 +21,7 @@
 #pragma once
 #include <sys/types.h> /* necessary for int32_t */
 
+#define PCI_VENDOR_ID_AMD     0x1002
 #define PCI_VENDOR_ID_NVIDIA  0x10de
 #define PCI_VENDOR_ID_INTEL   0x8086
 #define PCI_CLASS_DISPLAY_VGA 0x0300


### PR DESCRIPTION
Support AMD integrated graphics (amdgpu/radeon) + NVIDIA discrete graphics.

This setup is weird, but exists. AMD's integrated graphics are powerful than Intel's, so we will not bother to turn on discrete graphics unless we want to play games.

Only `amdgpu+nvidia` and `radeon+nvidia` were tested.

nouveau is untested because it's too unstable.

Screenshot:
![2018-12-03 15-36-55](https://user-images.githubusercontent.com/34613827/49360986-bd790900-f715-11e8-8ed7-487be746b8c4.png)
