### PR TITLE
Fix pcie id string overrun

### DIFF
--- a/src/bbsecondary.c
+++ b/src/bbsecondary.c
@@ -136,9 +136,10 @@ bool start_secondary(bool need_secondary) {
     return true;
   //no problems, start X if not started yet
   if (!bb_is_running(bb_status.x_pid)) {
-    char pci_id[12];
+    char pci_id[13];
     static char *x_conf_file;
-    snprintf(pci_id, 12, "PCI:%02d:%02d:%o", pci_bus_id_discrete->bus,
+    // 0-255 bus, 0-31 slot, 0-7 func
+    snprintf(pci_id, 13, "PCI:%03d:%02d:%o", pci_bus_id_discrete->bus,
             pci_bus_id_discrete->slot, pci_bus_id_discrete->func);
     if (!x_conf_file) {
       x_conf_file = xorg_path_w_driver(bb_config.x_conf_file, bb_config.driver);


### PR DESCRIPTION
Bumblebeed tries to launch xorg server with an invalid command line when the discrete GPU is located on a bus higher than 99. This change makes the correct command line for devices on all 256 buses.

Before:
```
[361129.431640] [DEBUG]X server command line:[361129.431650] [DEBUG] /usr/lib/xorg/Xorg[361129.431660] [DEBUG] :8[361129.431668] [DEBUG] -config[361129.431676] [DEBUG] /etc/bumblebee/xorg.conf.nvidia[361129.431689] [DEBUG] -configdir[361129.431697] [DEBUG] /etc/bumblebee/xorg.conf.d[361129.431706] [DEBUG] -sharevts[361129.431714] [DEBUG] -nolisten[361129.431722] [DEBUG] tcp[361129.431727] [DEBUG] -noreset[361129.431735] [DEBUG] -verbose[361129.431740] [DEBUG] 3[361129.431747] [DEBUG] -isolateDevice[361129.431753] [DEBUG] PCI:177:00:[361129.431761] [DEBUG] -modulepath[361129.431767] [DEBUG] /usr/lib/nvidia-410/xorg,/usr/lib/xorg/modules[361129.431775] [DEBUG]
```

After:
```
[360688.869098] [DEBUG]X server command line:[360688.869108] [DEBUG] /usr/lib/xorg/Xorg[360688.869115] [DEBUG] :8[360688.869121] [DEBUG] -config[360688.869128] [DEBUG] /etc/bumblebee/xorg.conf.nvidia[360688.869136] [DEBUG] -configdir[360688.869142] [DEBUG] /etc/bumblebee/xorg.conf.d[360688.869155] [DEBUG] -sharevts[360688.869163] [DEBUG] -nolisten[360688.869169] [DEBUG] tcp[360688.869177] [DEBUG] -noreset[360688.869183] [DEBUG] -verbose[360688.869192] [DEBUG] 3[360688.869198] [DEBUG] -isolateDevice[360688.869207] [DEBUG] PCI:177:00:0[360688.869216] [DEBUG] -modulepath[360688.869225] [DEBUG] /usr/lib/nvidia-410/xorg,/usr/lib/xorg/modules[360688.869234] [DEBUG]```