### PR TITLE
Add GLXName option to override PRIMUS_libGLa to make it work with GLVND

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -97,6 +97,7 @@ do_subst = sed -e 's|[@]GITVERSION[@]|$(GITVERSION)|g' \
 	-e 's|[@]XCONFDDIR[@]|$(xconfddir)|g' \
 	-e 's|[@]CONF_DRIVER_MODULE_NVIDIA[@]|$(CONF_DRIVER_MODULE_NVIDIA)|g' \
 	-e 's|[@]CONF_LDPATH_NVIDIA[@]|$(CONF_LDPATH_NVIDIA)|g' \
+	-e 's|[@]CONF_GLXNAME_NVIDIA[@]|$(CONF_GLXNAME_NVIDIA)|g' \
 	-e 's|[@]CONF_MODPATH_NVIDIA[@]|$(CONF_MODPATH_NVIDIA)|g' \
 	-e 's|[@]CONF_PIDFILE[@]|$(CONF_PIDFILE)|g'
 

--- a/conf/bumblebee.conf.in
+++ b/conf/bumblebee.conf.in
@@ -58,6 +58,9 @@ KernelDriver=@CONF_DRIVER_MODULE_NVIDIA@
 PMMethod=@CONF_PM_METHOD@
 # colon-separated path to the nvidia libraries
 LibraryPath=@CONF_LDPATH_NVIDIA@
+# name of the nvidia-specific GLX implementation - needs to be libGLX_nvidia.so.0
+# when using the GLVND libraries (435+) to work with Primus
+GLXName=@CONF_GLXNAME_NVIDIA@
 # comma-separated path of the directory containing nvidia_drv.so and the
 # default Xorg modules path
 XorgModulePath=@CONF_MODPATH_NVIDIA@

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,12 @@ AC_DEFINE_CONF(CONF_DRIVER_MODULE_NVIDIA, [name of module for nvidia driver, i.e
 AC_DEFINE_CONF(CONF_LDPATH_NVIDIA, [Path to nvidia libraries for nvidia driver])
 AC_DEFINE_CONF(CONF_MODPATH_NVIDIA, [ModulePath for xorg modules when using nvidia driver])
 
+AC_DEFINE_CONF(CONF_GLXNAME_NVIDIA, [Name of the GLX library. Default: libGL.so.1], [
+if test "x" = "x$CONF_GLXNAME_NVIDIA"; then
+	CONF_GLXNAME_NVIDIA="libGL.so.1"
+fi
+])
+
 # non-config related compile-time defines
 AC_DEFINE(DAEMON_NAME, "bumblebeed", "daemon name")
 

--- a/src/bbconfig.c
+++ b/src/bbconfig.c
@@ -485,6 +485,10 @@ void bbconfig_parse_conf_driver(GKeyFile *bbcfg, char *driver) {
   if (g_key_file_has_key(bbcfg, section, key, NULL)) {
     free_and_set_value(&bb_config.x_conf_file, g_key_file_get_string(bbcfg, section, key, NULL));
   }
+  key = "GLXName";
+  if (g_key_file_has_key(bbcfg, section, key, NULL)) {
+    free_and_set_value(&bb_config.glx_name, g_key_file_get_string(bbcfg, section, key, NULL));
+  }
   if (err != NULL) {
     g_error_free(err);
   }
@@ -520,6 +524,7 @@ void init_config(void) {
   set_string_value(&bb_config.x_display, CONF_XDISP);
   set_string_value(&bb_config.bb_conf_file, CONFIG_FILE);
   set_string_value(&bb_config.ld_path, "");
+  set_string_value(&bb_config.glx_name, "libGL.so.1");
   set_string_value(&bb_config.mod_path, "");
   set_string_value(&bb_config.socket_path, CONF_SOCKPATH);
   set_string_value(&bb_config.gid_name, CONF_GID);
@@ -551,6 +556,7 @@ void config_dump(void) {
   bb_log(LOG_DEBUG, " bumblebeed config file: %s\n", bb_config.bb_conf_file);
   bb_log(LOG_DEBUG, " X display: %s\n", bb_config.x_display);
   bb_log(LOG_DEBUG, " LD_LIBRARY_PATH: %s\n", bb_config.ld_path);
+  bb_log(LOG_DEBUG, " GLX library name: %s\n", bb_config.glx_name);
   bb_log(LOG_DEBUG, " Socket path: %s\n", bb_config.socket_path);
   if (bb_status.runmode == BB_RUN_SERVER || bb_status.runmode == BB_RUN_DAEMON) {
     /* daemon options */

--- a/src/bbconfig.h
+++ b/src/bbconfig.h
@@ -130,6 +130,7 @@ struct bb_config_struct {
     char * x_conf_dir; /// Path to the dummy X configuration directory.
     char * bb_conf_file; /// Path to the bumblebeed configuration file.
     char * ld_path; /// LD_LIBRARY_PATH to launch applications.
+    char * glx_name; /// GLX implementation library name. Default: libGL.so.1
     char * mod_path; /// ModulePath for xorg.
     char * socket_path; /// Path to the server socket.
     char * gid_name; /// Group name for setgid.

--- a/src/bumblebeed.c
+++ b/src/bumblebeed.c
@@ -233,6 +233,8 @@ static void handle_socket(struct clientsocket * C) {
             snprintf(buffer, BUFFER_SIZE, "Value: %s\n", bb_config.x_display);
           } else if (strcmp(conf_key, "LibraryPath") == 0) {
             snprintf(buffer, BUFFER_SIZE, "Value: %s\n", bb_config.ld_path);
+          } else if (strcmp(conf_key, "GLXName") == 0) {
+            snprintf(buffer, BUFFER_SIZE, "Value: %s\n", bb_config.glx_name);
           } else if (strcmp(conf_key, "Driver") == 0) {
             /* note: this is not the auto-detected value, but the actual one */
             snprintf(buffer, BUFFER_SIZE, "Value: %s\n", bb_config.driver);


### PR DESCRIPTION
When using a GLVND-only Nvidia driver (435+) with Primus, PRIMUS_libGLa
needs to point to libGLX_nvidia.so.0 to work.
Add an option to override the default hard-coded libGL.so.1, set its
default to the old value and document its purpose in the configuration
file.

Suggested-by: Felix Dörre <debian@felixdoerre.de>

@felixdoerre FYI