### PR TITLE
docs: fix simple typo, succesfully -> successfully

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -64,7 +64,7 @@ int module_is_loaded(char *driver) {
  *
  * @param module_name The filename of the module to be loaded
  * @param driver The name of the driver to be loaded
- * @return 1 if the driver is succesfully loaded, 0 otherwise
+ * @return 1 if the driver is successfully loaded, 0 otherwise
  */
 int module_load(char *module_name, char *driver) {
   if (module_is_loaded(driver) == 0) {
@@ -89,7 +89,7 @@ int module_load(char *module_name, char *driver) {
  * giving up
  *
  * @param driver The name of the driver (not a filename)
- * @return 1 if the driver is succesfully unloaded, 0 otherwise
+ * @return 1 if the driver is successfully unloaded, 0 otherwise
  */
 int module_unload(char *driver) {
   if (module_is_loaded(driver) == 1) {

--- a/src/optirun.c
+++ b/src/optirun.c
@@ -62,7 +62,7 @@ static void handle_signal(int sig) {
 
 /**
  * Prints the status of the Bumblebee server if available
- * @return EXIT_SUCCESS if the status is succesfully retrieved,
+ * @return EXIT_SUCCESS if the status is successfully retrieved,
  * EXIT_FAILURE otherwise
  */
 static int report_daemon_status(void) {


### PR DESCRIPTION
There is a small typo in src/module.c, src/optirun.c.

Should read `successfully` rather than `succesfully`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md