### PR TITLE
Remove check for Intel GPU

### DIFF
--- a/src/bumblebeed.c
+++ b/src/bumblebeed.c
@@ -472,37 +472,11 @@ int main(int argc, char* argv[]) {
     return (EXIT_FAILURE);
   }
 
-  struct pci_bus_id *pci_id_igd;
-  pci_id_igd = pci_find_gfx_by_vendor(PCI_VENDOR_ID_INTEL, 0);
-  if (!pci_id_igd) {
-    if (bb_status.card_type == CARD_ATI) {
-      /* assume the first AMD video card to be integrated */
-      pci_id_igd = pci_bus_id_discrete;
-      pci_bus_id_discrete = pci_find_gfx_by_vendor(PCI_VENDOR_ID_ATI, 1);
-      if (!pci_bus_id_discrete) {
-        bb_log(LOG_ERR, "No AMD Switchable Graphics detected, quitting.\n");
-        return (EXIT_FAILURE);
-      }
-    } else {
-      /* maybe it is a nvidia/nvidia setup. Assume the second card to be the
-       * iGPU (as is the case with MacBook Pro 2009 */
-      pci_id_igd = pci_find_gfx_by_vendor(PCI_VENDOR_ID_NVIDIA, 1);
-      if (!pci_id_igd) {
-        bb_log(LOG_ERR, "No hybrid Nvidia graphics detected, quitting.\n");
-        return (EXIT_FAILURE);
-      }
-    }
-  }
-
   bb_log(LOG_DEBUG, "Found card: %02x:%02x.%x (discrete %s)\n",
     pci_bus_id_discrete->bus, pci_bus_id_discrete->slot,
     pci_bus_id_discrete->func,
     (bb_status.card_type == CARD_NVIDIA ? "nvidia" :
     (bb_status.card_type == CARD_ATI ? "amd" : "unknown")));
-  bb_log(LOG_DEBUG, "Found card: %02x:%02x.%x (integrated)\n", pci_id_igd->bus,
-    pci_id_igd->slot, pci_id_igd->func);
-
-  free(pci_id_igd);
 
   GKeyFile *bbcfg = bbconfig_parse_conf();
   bbconfig_parse_opts(argc, argv, PARSE_STAGE_DRIVER);


### PR DESCRIPTION
Bumblebee has nothing specific for Intel GPUs, but the code contains a check that makes it fail to work unless such a GPU is present.

This patch removes the useless and damaging check.