### PR TITLE
Remove check for Intel GPUs

### DIFF
--- a/src/bumblebeed.c
+++ b/src/bumblebeed.c
@@ -461,22 +461,6 @@ int main(int argc, char* argv[]) {
   init_config();
   bbconfig_parse_opts(argc, argv, PARSE_STAGE_PRECONF);
 
-  /* First look for an intel card */
-  struct pci_bus_id *pci_id_igd = pci_find_gfx_by_vendor(PCI_VENDOR_ID_INTEL, 0);
-  if (!pci_id_igd) {
-    /* This is no Optimus configuration. But maybe it's a
-       dual-nvidia configuration. Let us test that.
-    */
-    pci_id_igd = pci_find_gfx_by_vendor(PCI_VENDOR_ID_NVIDIA, 1);
-    bb_log(LOG_INFO, "No Intel video card found, testing for dual-nvidia system.\n");
-
-    if (!pci_id_igd) {
-      /* Ok, this is not a double gpu setup supported (there is at most
-         one nvidia and no intel cards */
-      bb_log(LOG_ERR, "No integrated video card found, quitting.\n");
-      return (EXIT_FAILURE);
-    }
-  }
   pci_bus_id_discrete = pci_find_gfx_by_vendor(PCI_VENDOR_ID_NVIDIA, 0);
   if (!pci_bus_id_discrete) {
     bb_log(LOG_ERR, "No discrete video card found, quitting\n");
@@ -484,9 +468,6 @@ int main(int argc, char* argv[]) {
   }
 
   bb_log(LOG_DEBUG, "Found card: %02x:%02x.%x (discrete)\n", pci_bus_id_discrete->bus, pci_bus_id_discrete->slot, pci_bus_id_discrete->func);
-  bb_log(LOG_DEBUG, "Found card: %02x:%02x.%x (integrated)\n", pci_id_igd->bus, pci_id_igd->slot, pci_id_igd->func);
-
-  free(pci_id_igd);
 
   GKeyFile *bbcfg = bbconfig_parse_conf();
   bbconfig_parse_opts(argc, argv, PARSE_STAGE_DRIVER);


### PR DESCRIPTION
Bumblebee has no code specific to Intel GPUs, but the code contains a check that makes it fail to work unless such a GPU is present.

This patch removes that useless and disastrous check.

I think the check for the discrete nVidia GPU is also useless, since bumblebee should very well work for ANY GPU, but that's a bit harder to remove.
